### PR TITLE
Update translation of kernel metadata to work with new metadata format.

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -171,51 +171,6 @@ void OCLTypeToSPIRV::adaptFunction(Function *F) {
   addAdaptedType(F, FT);
 }
 
-MDNode *OCLTypeToSPIRV::getArgAccessQualifierMetadata(Function *F) {
-  return getArgMetadata(F, SPIR_MD_KERNEL_ARG_ACCESS_QUAL);
-}
-
-MDNode *OCLTypeToSPIRV::getKernelMetadata(Function *F) {
-  NamedMDNode *KernelMDs = M->getNamedMetadata(SPIR_MD_KERNELS);
-  if (!KernelMDs)
-    return nullptr;
-
-  for (unsigned I = 0, E = KernelMDs->getNumOperands(); I < E; ++I) {
-    MDNode *KernelMD = KernelMDs->getOperand(I);
-    if (KernelMD->getNumOperands() == 0)
-      continue;
-    Function *Kernel = mdconst::dyn_extract<Function>(KernelMD->getOperand(0));
-
-    if (Kernel == F)
-      return KernelMD;
-  }
-  return nullptr;
-}
-
-MDNode *OCLTypeToSPIRV::getArgMetadata(Function *F, const std::string &MDName) {
-  auto KernelMD = getKernelMetadata(F);
-  if (!KernelMD)
-    return nullptr;
-
-  for (unsigned MI = 1, ME = KernelMD->getNumOperands(); MI < ME; ++MI) {
-    MDNode *MD = dyn_cast<MDNode>(KernelMD->getOperand(MI));
-    if (!MD)
-      continue;
-    MDString *NameMD = dyn_cast<MDString>(MD->getOperand(0));
-    if (!NameMD)
-      continue;
-    StringRef Name = NameMD->getString();
-    if (Name == MDName) {
-      return MD;
-    }
-  }
-  return nullptr;
-}
-
-MDNode *OCLTypeToSPIRV::getArgBaseTypeMetadata(Function *F) {
-  return getArgMetadata(F, SPIR_MD_KERNEL_ARG_BASE_TYPE);
-}
-
 // Handle functions with sampler arguments that don't get called by
 // a kernel function.
 void OCLTypeToSPIRV::adaptArgumentsBySamplerUse(Module &M) {
@@ -263,7 +218,7 @@ void OCLTypeToSPIRV::adaptArgumentsBySamplerUse(Module &M) {
 }
 
 void OCLTypeToSPIRV::adaptFunctionArguments(Function *F) {
-  auto TypeMD = getArgBaseTypeMetadata(F);
+  auto TypeMD = F->getMetadata(SPIR_MD_KERNEL_ARG_BASE_TYPE);
   if (TypeMD)
     return;
   bool Changed = false;
@@ -294,14 +249,14 @@ void OCLTypeToSPIRV::adaptFunctionArguments(Function *F) {
 /// types and use them to map the function arguments to the SPIR-V type.
 /// ToDo: Map other OpenCL opaque types to SPIR-V types.
 void OCLTypeToSPIRV::adaptArgumentsByMetadata(Function *F) {
-  auto TypeMD = getArgBaseTypeMetadata(F);
+  auto TypeMD = F->getMetadata(SPIR_MD_KERNEL_ARG_BASE_TYPE);
   if (!TypeMD)
     return;
   bool Changed = false;
   auto FT = F->getFunctionType();
   auto PI = FT->param_begin();
   auto Arg = F->arg_begin();
-  for (unsigned I = 1, E = TypeMD->getNumOperands(); I != E; ++I, ++PI, ++Arg) {
+  for (unsigned I = 0, E = TypeMD->getNumOperands(); I != E; ++I, ++PI, ++Arg) {
     auto OCLTyStr = getMDOperandAsString(TypeMD, I);
     auto NewTy = *PI;
     if (OCLTyStr == OCL_TYPE_NAME_SAMPLER_T && !NewTy->isStructTy()) {
@@ -312,7 +267,7 @@ void OCLTypeToSPIRV::adaptArgumentsByMetadata(Function *F) {
       if (STName.startswith(kSPR2TypeName::ImagePrefix) ||
           STName == kSPR2TypeName::Pipe) {
         auto Ty = STName.str();
-        auto AccMD = getArgAccessQualifierMetadata(F);
+        auto AccMD = F->getMetadata(SPIR_MD_KERNEL_ARG_ACCESS_QUAL);
         assert(AccMD && "Invalid access qualifier metadata");
         auto AccStr = getMDOperandAsString(AccMD, I);
         addAdaptedType(&(*Arg), getOrCreateOpaquePtrType(

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -75,10 +75,6 @@ private:
   std::map<Value *, Type *> AdaptedTy; // Adapted types for values
   std::set<Function *> WorkSet;        // Functions to be adapted
 
-  MDNode *getArgBaseTypeMetadata(Function *);
-  MDNode *getArgAccessQualifierMetadata(Function *);
-  MDNode *getArgMetadata(Function *, const std::string &MDName);
-  MDNode *getKernelMetadata(Function *F);
   void adaptFunctionArguments(Function *F);
   void adaptArgumentsByMetadata(Function *F);
   void adaptArgumentsBySamplerUse(Module &M);

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -214,9 +214,9 @@ unsigned getOCLVersion(Module *M, bool AllowMulti) {
 void decodeMDNode(MDNode *N, unsigned &X, unsigned &Y, unsigned &Z) {
   if (N == NULL)
     return;
-  X = getMDOperandAsInt(N, 1);
-  Y = getMDOperandAsInt(N, 2);
-  Z = getMDOperandAsInt(N, 3);
+  X = getMDOperandAsInt(N, 0);
+  Y = getMDOperandAsInt(N, 1);
+  Z = getMDOperandAsInt(N, 2);
 }
 
 /// Encode LLVM type by SPIR-V execution mode VecTypeHint
@@ -278,7 +278,7 @@ Type *decodeVecTypeHint(LLVMContext &C, unsigned Code) {
 }
 
 unsigned transVecTypeHint(MDNode *Node) {
-  return encodeVecTypeHint(getMDOperandAsType(Node, 1));
+  return encodeVecTypeHint(getMDOperandAsType(Node, 0));
 }
 
 SPIRAddressSpace getOCLOpaqueTypeAddrSpace(Op OpCode) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -110,8 +110,8 @@ static void foreachKernelArgMD(
     MDNode *MD, SPIRVFunction *BF,
     std::function<void(const std::string &Str, SPIRVFunctionParameter *BA)>
         Func) {
-  for (unsigned I = 1, E = MD->getNumOperands(); I != E; ++I) {
-    SPIRVFunctionParameter *BA = BF->getArgument(I - 1);
+  for (unsigned I = 0, E = MD->getNumOperands(); I != E; ++I) {
+    SPIRVFunctionParameter *BA = BF->getArgument(I);
     Func(getMDOperandAsString(MD, I), BA);
   }
 }
@@ -1605,34 +1605,30 @@ bool LLVMToSPIRV::transOCLKernelMetadata() {
     assert(BF && "Kernel function should be translated first");
     assert(Kernel && oclIsKernel(Kernel) &&
            "Invalid kernel calling convention or metadata");
-    for (unsigned MI = 1, ME = KernelMD->getNumOperands(); MI < ME; ++MI) {
-      MDNode *MD = dyn_cast<MDNode>(KernelMD->getOperand(MI));
-      if (!MD)
-        continue;
-      MDString *NameMD = dyn_cast<MDString>(MD->getOperand(0));
-      if (!NameMD)
-        continue;
-      StringRef Name = NameMD->getString();
-      if (Name == SPIR_MD_KERNEL_ARG_TYPE_QUAL) {
-        foreachKernelArgMD(
-            MD, BF, [](const std::string &Str, SPIRVFunctionParameter *BA) {
-              if (Str.find("volatile") != std::string::npos)
-                BA->addDecorate(new SPIRVDecorate(DecorationVolatile, BA));
-              if (Str.find("restrict") != std::string::npos)
-                BA->addDecorate(
-                    new SPIRVDecorate(DecorationFuncParamAttr, BA,
-                                      FunctionParameterAttributeNoAlias));
-              if (Str.find("const") != std::string::npos)
-                BA->addDecorate(
-                    new SPIRVDecorate(DecorationFuncParamAttr, BA,
-                                      FunctionParameterAttributeNoWrite));
-            });
-      } else if (Name == SPIR_MD_KERNEL_ARG_NAME) {
-        foreachKernelArgMD(
-            MD, BF, [=](const std::string &Str, SPIRVFunctionParameter *BA) {
-              BM->setName(BA, Str);
-            });
-      }
+
+    if (auto *KernelArgTypeQual =
+            Kernel->getMetadata(SPIR_MD_KERNEL_ARG_TYPE_QUAL)) {
+      foreachKernelArgMD(
+          KernelArgTypeQual, BF,
+          [](const std::string &Str, SPIRVFunctionParameter *BA) {
+            if (Str.find("volatile") != std::string::npos)
+              BA->addDecorate(new SPIRVDecorate(DecorationVolatile, BA));
+            if (Str.find("restrict") != std::string::npos)
+              BA->addDecorate(
+                  new SPIRVDecorate(DecorationFuncParamAttr, BA,
+                                    FunctionParameterAttributeNoAlias));
+            if (Str.find("const") != std::string::npos)
+              BA->addDecorate(
+                  new SPIRVDecorate(DecorationFuncParamAttr, BA,
+                                    FunctionParameterAttributeNoWrite));
+          });
+    }
+    if (auto *KernelArgName = Kernel->getMetadata(SPIR_MD_KERNEL_ARG_NAME)) {
+      foreachKernelArgMD(
+          KernelArgName, BF,
+          [=](const std::string &Str, SPIRVFunctionParameter *BA) {
+            BM->setName(BA, Str);
+          });
     }
   }
   return true;

--- a/test/ExecutionMode_SPIR_to_SPIRV.ll
+++ b/test/ExecutionMode_SPIR_to_SPIRV.ll
@@ -19,34 +19,24 @@
 
 ; CHECK-LLVM: [[WG]] = !{i32 128, i32 10, i32 1}
 
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
-target triple = "spir-unknown-unknown"
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
 
-; Function Attrs: nounwind
-define spir_kernel void @worker() #0 {
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @worker() local_unnamed_addr #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !1 !kernel_arg_type !1 !kernel_arg_base_type !1 !kernel_arg_type_qual !1 !work_group_size_hint !3 {
 entry:
   ret void
 }
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { norecurse nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 
-!opencl.kernels = !{!0}
 !opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!7}
-!opencl.ocl.version = !{!7}
-!opencl.used.extensions = !{!8}
-!opencl.used.optional.core.features = !{!8}
-!opencl.compiler.options = !{!8}
-!llvm.ident = !{!9}
+!opencl.ocl.version = !{!0}
+!opencl.spir.version = !{!0}
+!opencl.used.extensions = !{!1}
+!opencl.used.optional.core.features = !{!1}
+!opencl.compiler.options = !{!1}
 
-!0 = !{void ()* @worker, !1, !2, !3, !4, !5, !6}
-!1 = !{!"kernel_arg_addr_space"}
-!2 = !{!"kernel_arg_access_qual"}
-!3 = !{!"kernel_arg_type"}
-!4 = !{!"kernel_arg_base_type"}
-!5 = !{!"kernel_arg_type_qual"}
-!6 = !{!"work_group_size_hint", i32 128, i32 10, i32 1}
-!7 = !{i32 1, i32 2}
-!8 = !{}
-!9 = !{!"clang version 3.6.1 "}
+!0 = !{i32 1, i32 2}
+!1 = !{}
+!3 = !{i32 128, i32 10, i32 1}

--- a/test/group-decorate.ll
+++ b/test/group-decorate.ll
@@ -11,7 +11,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK: 4 GroupDecorate [[GID2]]
 
 ; Function Attrs: nounwind readnone
-define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) #0 {
+define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
 entry:
   ret void
 }
@@ -26,12 +26,12 @@ attributes #0 = { nounwind readnone }
 !opencl.used.optional.core.features = !{!7}
 !opencl.compiler.options = !{!8}
 
-!0 = !{void (<4 x i8> addrspace(1)*, <4 x i8> addrspace(1)*, <4 x i8> addrspace(1)*)* @test, !1, !2, !3, !4, !5}
-!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1}
-!2 = !{!"kernel_arg_access_qual", !"none", !"none", !"none"}
-!3 = !{!"kernel_arg_type", !"char4*", !"char4*", !"char4*"}
-!4 = !{!"kernel_arg_type_qual", !"const", !"const", !""}
-!5 = !{!"kernel_arg_base_type", !"char4*", !"char4*", !"char4*"}
+!0 = !{void (<4 x i8> addrspace(1)*, <4 x i8> addrspace(1)*, <4 x i8> addrspace(1)*)* @test}
+!1 = !{i32 1, i32 1, i32 1}
+!2 = !{!"none", !"none", !"none"}
+!3 = !{!"char4*", !"char4*", !"char4*"}
+!4 = !{!"const", !"const", !""}
+!5 = !{!"char4*", !"char4*", !"char4*"}
 !6 = !{i32 1, i32 2}
 !7 = !{}
 !8 = !{!""}

--- a/test/half_extension.ll
+++ b/test/half_extension.ll
@@ -12,8 +12,7 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 
-; CHECK-SPIRV: {{[0-9]+}} Capability Float16Buffer 
-; CHECK-SPIRV: {{[0-9]+}} Capability Float16 
+; CHECK-SPIRV: {{[0-9]+}} Capability Float16
 
 ; ModuleID = 'main'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/image.ll
+++ b/test/image.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 %opencl.image2d_t = type opaque
 
 ; Function Attrs: nounwind
-define spir_kernel void @image_copy(%opencl.image2d_t addrspace(1)* readnone %image1, %opencl.image2d_t addrspace(1)* %image2) #0 {
+define spir_kernel void @image_copy(%opencl.image2d_t addrspace(1)* readnone %image1, %opencl.image2d_t addrspace(1)* %image2) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
 entry:
   %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
   %conv = trunc i64 %call to i32
@@ -48,12 +48,12 @@ attributes #4 = { nounwind }
 !opencl.compiler.options = !{!7}
 !llvm.ident = !{!9}
 
-!0 = !{void (%opencl.image2d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*)* @image_copy, !1, !2, !3, !4, !5}
-!1 = !{!"kernel_arg_addr_space", i32 1, i32 1}
-!2 = !{!"kernel_arg_access_qual", !"read_only", !"write_only"}
-!3 = !{!"kernel_arg_type", !"image2d_t", !"image2d_t"}
-!4 = !{!"kernel_arg_type_qual", !"", !""}
-!5 = !{!"kernel_arg_base_type", !"image2d_t", !"image2d_t"}
+!0 = !{void (%opencl.image2d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*)* @image_copy}
+!1 = !{i32 1, i32 1}
+!2 = !{!"read_only", !"write_only"}
+!3 = !{!"image2d_t", !"image2d_t"}
+!4 = !{!"", !""}
+!5 = !{!"image2d_t", !"image2d_t"}
 !6 = !{i32 2, i32 0}
 !7 = !{}
 !8 = !{!"cl_images"}

--- a/test/multi_md.ll
+++ b/test/multi_md.ll
@@ -47,8 +47,8 @@ attributes #0 = { nounwind }
 ; "cl_images" should be encoded as BasicImage capability, 
 ; but images are not used in this test case, so this capability is not required.
 ; CHECK-NOT: 4 Extension "cl_images"
-; CHECK-DAG: 8 Extension "cl_khr_int64_base_atomics"
-; CHECK-DAG: 9 Extension "cl_khr_int64_extended_atomics"
+; CHECK-DAG: 8 SourceExtension "cl_khr_int64_base_atomics"
+; CHECK-DAG: 9 SourceExtension "cl_khr_int64_extended_atomics"
 ; CHECK: 3 Source 3 200000
 
 !opencl.kernels = !{!0, !7}

--- a/test/transcoding/cl-types.ll
+++ b/test/transcoding/cl-types.ll
@@ -100,7 +100,7 @@ define spir_kernel void @foo(
   %opencl.image1d_buffer_t addrspace(1)* nocapture %g1,
   %opencl.image1d_t addrspace(1)* nocapture %c2,
   %opencl.image2d_t addrspace(1)* nocapture %d3,
-  i32 %s) #0 {
+  i32 %s) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
 ; CHECK-SPIRV: 5 SampledImage [[SAMPIMG]] [[SAMPIMG_VAR1:[0-9]+]] [[IMG_ARG]] [[SAMP_ARG]]
 ; CHECK-SPIRV: 7 ImageSampleExplicitLod {{[0-9]+}} {{[0-9]+}} [[SAMPIMG_VAR1]]
@@ -133,11 +133,11 @@ attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-point
 ; CHECK-LLVM-DAG: [[TQ]] = !{!"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !"", !""}
 
 !0 = !{void (%opencl.pipe_t addrspace(1)*, %opencl.pipe_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*, %opencl.image3d_t addrspace(1)*, %opencl.image2d_array_t addrspace(1)*, %opencl.image1d_buffer_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*, i32)* @foo, !1, !2, !3, !4, !5}
-!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 0}
-!2 = !{!"kernel_arg_access_qual", !"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write", !"none"}
-!3 = !{!"kernel_arg_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
-!4 = !{!"kernel_arg_base_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
-!5 = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !"", !""}
+!1 = !{i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 0}
+!2 = !{!"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write", !"none"}
+!3 = !{!"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
+!4 = !{!"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
+!5 = !{!"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !"", !""}
 !6 = !{i32 1, i32 2}
 !7 = !{i32 2, i32 0}
 !8 = !{}

--- a/test/transcoding/pipe_builtins.ll
+++ b/test/transcoding/pipe_builtins.ll
@@ -109,7 +109,7 @@
 
 ; ModuleID = 'pipe_builtins.cl'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir64-unknonw-unknown"
+target triple = "spir64-unknown-unknown"
 
 %opencl.reserve_id_t = type opaque
 %opencl.pipe_t = type opaque
@@ -117,77 +117,78 @@ target triple = "spir64-unknonw-unknown"
 @test_pipe_workgroup_write_char.res_id = internal unnamed_addr addrspace(3) global %opencl.reserve_id_t* undef, align 8
 @test_pipe_workgroup_read_char.res_id = internal unnamed_addr addrspace(3) global %opencl.reserve_id_t* undef, align 8
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_convenience_write_uint(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_convenience_write_uint(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !7 !kernel_arg_type_qual !8 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_convenience_write_uint
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %0 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %0, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %src, i64 %idxprom
-  %0 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %1 = addrspacecast i8 addrspace(1)* %0 to i8 addrspace(4)*
+  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
   ; CHECK-LLVM: call{{.*}}@__write_pipe_2
   ; CHECK-SPIRV: WritePipe {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %2 = tail call i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, i8 addrspace(4)* %1, i32 4, i32 4) #2
+  %3 = tail call i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, i8 addrspace(4)* %2, i32 4, i32 4) #5
   ret void
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare spir_func i64 @_Z13get_global_idj(i32) #1
+; Function Attrs: convergent nounwind readnone
+declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr #1
 
-declare i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+declare i32 @_Z10write_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)*, i8 addrspace(4)*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_convenience_read_uint(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_convenience_read_uint(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !12 !kernel_arg_type !13 !kernel_arg_base_type !14 !kernel_arg_type_qual !15 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_convenience_read_uint
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %0 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %0, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %idxprom
-  %0 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %1 = addrspacecast i8 addrspace(1)* %0 to i8 addrspace(4)*
+  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
   ; CHECK-LLVM: call{{.*}}@__read_pipe_2
   ; CHECK-SPIRV: ReadPipe {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %2 = tail call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, i8 addrspace(4)* %1, i32 4, i32 4) #2
+  %3 = tail call i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, i8 addrspace(4)* %2, i32 4, i32 4) #5
   ret void
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+declare i32 @_Z9read_pipePU3AS18ocl_pipePU3AS4vjj(%opencl.pipe_t addrspace(1)*, i8 addrspace(4)*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_write(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_write(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !16 !kernel_arg_base_type !16 !kernel_arg_type_qual !8 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_write
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
   ; CHECK-LLVM: @__reserve_write_pipe
   ; CHECK-SPIRV: ReserveWritePipePackets {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %0 = tail call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 1, i32 4, i32 4) #2
-  %call1 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #2
+  %0 = tail call %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 1, i32 4, i32 4) #5
+  %call1 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #6
   br i1 %call1, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %1 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %1, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %src, i64 %idxprom
-  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
+  %2 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %3 = addrspacecast i8 addrspace(1)* %2 to i8 addrspace(4)*
   ; CHECK-LLVM: call{{.*}}@__write_pipe_4
   ; CHECK-SPIRV: ReservedWritePipe {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %3 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 0, i8 addrspace(4)* %2, i32 4, i32 4) #2
+  %4 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 0, i8 addrspace(4)* %3, i32 4, i32 4) #5
   ; CHECK-LLVM: call{{.*}}@__commit_write_pipe
   ; CHECK-SPIRV: CommitWritePipe [[PipeArgID]] {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z17commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #2
+  tail call void @_Z17commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -195,61 +196,62 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z18reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t*) #1
+; Function Attrs: convergent
+declare spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t*) local_unnamed_addr #2
 
-declare i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i8 addrspace(4)*, i32, i32)
+declare i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i8 addrspace(4)*, i32, i32) local_unnamed_addr
 
-declare void @_Z17commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z17commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
 ; Function Attrs: nounwind
-define spir_kernel void @test_pipe_query_functions(%opencl.pipe_t addrspace(1)* %out_pipe, i32 addrspace(1)* nocapture %num_packets, i32 addrspace(1)* nocapture %max_packets) #0 {
+define spir_kernel void @test_pipe_query_functions(%opencl.pipe_t addrspace(1)* %out_pipe, i32 addrspace(1)* nocapture %num_packets, i32 addrspace(1)* nocapture %max_packets) local_unnamed_addr #3 !kernel_arg_addr_space !17 !kernel_arg_access_qual !18 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !20 !kernel_arg_host_accessible !21 !kernel_arg_pipe_depth !22 !kernel_arg_pipe_io !23 !kernel_arg_buffer_location !23 {
 ; CHECK-LLVM-LABEL: @test_pipe_query_functions
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
   ; CHECK-LLVM: call{{.*}}@__get_pipe_max_packets
   ; CHECK-SPIRV: GetMaxPipePackets {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}}
-  %0 = tail call i32 @_Z20get_pipe_max_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 4, i32 4) #2
-  store i32 %0, i32 addrspace(1)* %max_packets, align 4, !tbaa !35
+  %0 = tail call i32 @_Z20get_pipe_max_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 4, i32 4) #5
+  store i32 %0, i32 addrspace(1)* %max_packets, align 4, !tbaa !24
   ; CHECK-LLVM: call{{.*}}@__get_pipe_num_packets
   ; CHECK-SPIRV: GetNumPipePackets {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}}
-  %1 = tail call i32 @_Z20get_pipe_num_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 4, i32 4) #2
-  store i32 %1, i32 addrspace(1)* %num_packets, align 4, !tbaa !35
+  %1 = tail call i32 @_Z20get_pipe_num_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 4, i32 4) #5
+  store i32 %1, i32 addrspace(1)* %num_packets, align 4, !tbaa !24
   ret void
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare i32 @_Z20get_pipe_max_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)*, i32, i32)
+declare i32 @_Z20get_pipe_max_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)*, i32, i32) local_unnamed_addr
 
-declare i32 @_Z20get_pipe_num_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)*, i32, i32)
+declare i32 @_Z20get_pipe_num_packetsPU3AS18ocl_pipejj(%opencl.pipe_t addrspace(1)*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_read(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_read(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !12 !kernel_arg_type !28 !kernel_arg_base_type !28 !kernel_arg_type_qual !15 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_read
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
   ; CHECK-LLVM: call{{.*}}@__reserve_read_pipe
   ; CHECK-SPIRV: ReserveReadPipePackets {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %0 = tail call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 1, i32 4, i32 4) #2
-  %call1 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #2
+  %0 = tail call %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 1, i32 4, i32 4) #5
+  %call1 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #6
   br i1 %call1, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %1 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %1, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %idxprom
-  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
+  %2 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %3 = addrspacecast i8 addrspace(1)* %2 to i8 addrspace(4)*
   ; CHECK-LLVM: call{{.*}}@__read_pipe_4
   ; CHECK-SPIRV: ReservedReadPipe {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %3 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 0, i8 addrspace(4)* %2, i32 4, i32 4) #2
+  %4 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 0, i8 addrspace(4)* %3, i32 4, i32 4) #5
   ; CHECK-LLVM: call{{.*}}@__commit_read_pipe
   ; CHECK-SPIRV: CommitReadPipe [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z16commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #2
+  tail call void @_Z16commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -257,42 +259,42 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z17reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i8 addrspace(4)*, i32, i32)
+declare i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i8 addrspace(4)*, i32, i32) local_unnamed_addr
 
-declare void @_Z16commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z16commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_workgroup_write_char(i8 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_workgroup_write_char(i8 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !29 !kernel_arg_base_type !29 !kernel_arg_type_qual !8 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_workgroup_write_char
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = tail call spir_func i64 @_Z14get_local_sizej(i32 0) #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %call1 = tail call spir_func i64 @_Z14get_local_sizej(i32 0) #4
   %0 = trunc i64 %call1 to i32
   ; CHECK-LLVM: call{{.*}}@__work_group_reserve_write_pipe
   ; CHECK-SPIRV: GroupReserveWritePipePackets {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %1 = tail call %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 %0, i32 1, i32 1) #2
-  store %opencl.reserve_id_t* %1, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !39
-  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %1) #2
+  %1 = tail call %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 %0, i32 1, i32 1) #5
+  store %opencl.reserve_id_t* %1, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !30
+  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %1) #6
   br i1 %call2, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %2 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !39
-  %call3 = tail call spir_func i64 @_Z12get_local_idj(i32 0) #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %2 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !30
+  %call3 = tail call spir_func i64 @_Z12get_local_idj(i32 0) #4
+  %3 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %3, 32
   %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %src, i64 %idxprom
-  %3 = addrspacecast i8 addrspace(1)* %arrayidx to i8 addrspace(4)*
-  %4 = trunc i64 %call3 to i32
-  %5 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %2, i32 %4, i8 addrspace(4)* %3, i32 1, i32 1) #2
-  %6 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !39
+  %4 = addrspacecast i8 addrspace(1)* %arrayidx to i8 addrspace(4)*
+  %5 = trunc i64 %call3 to i32
+  %6 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %2, i32 %5, i8 addrspace(4)* %4, i32 1, i32 1) #5
+  %7 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_write_char.res_id, align 8, !tbaa !30
   ; CHECK-LLVM: call{{.*}}@__work_group_commit_write_pipe
   ; CHECK-SPIRV: GroupCommitWritePipe {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z28work_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %6, i32 1, i32 1) #2
+  tail call void @_Z28work_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %7, i32 1, i32 1) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -300,43 +302,45 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare spir_func i64 @_Z14get_local_sizej(i32) #1
+; Function Attrs: convergent nounwind readnone
+declare spir_func i64 @_Z14get_local_sizej(i32) local_unnamed_addr #1
 
-declare %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z29work_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare spir_func i64 @_Z12get_local_idj(i32) #1
+; Function Attrs: convergent nounwind readnone
+declare spir_func i64 @_Z12get_local_idj(i32) local_unnamed_addr #1
 
-declare void @_Z28work_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z28work_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_workgroup_read_char(%opencl.pipe_t addrspace(1)* %in_pipe, i8 addrspace(1)* %dst) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_workgroup_read_char(%opencl.pipe_t addrspace(1)* %in_pipe, i8 addrspace(1)* %dst) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !12 !kernel_arg_type !32 !kernel_arg_base_type !32 !kernel_arg_type_qual !15 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_workgroup_read_char
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = tail call spir_func i64 @_Z14get_local_sizej(i32 0) #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %call1 = tail call spir_func i64 @_Z14get_local_sizej(i32 0) #4
   %0 = trunc i64 %call1 to i32
   ; CHECK-LLVM: call{{.*}}@__work_group_reserve_read_pipe
   ; CHECK-SPIRV: GroupReserveReadPipePackets {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %1 = tail call %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 %0, i32 1, i32 1) #2
-  store %opencl.reserve_id_t* %1, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !39
-  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %1) #2
+  %1 = tail call %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 %0, i32 1, i32 1) #5
+  store %opencl.reserve_id_t* %1, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !30
+  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %1) #6
   br i1 %call2, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %2 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !39
-  %call3 = tail call spir_func i64 @_Z12get_local_idj(i32 0) #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %2 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !30
+  %call3 = tail call spir_func i64 @_Z12get_local_idj(i32 0) #4
+  %3 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %3, 32
   %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %dst, i64 %idxprom
-  %3 = addrspacecast i8 addrspace(1)* %arrayidx to i8 addrspace(4)*
-  %4 = trunc i64 %call3 to i32
-  %5 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %2, i32 %4, i8 addrspace(4)* %3, i32 1, i32 1) #2
-  %6 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !39
+  %4 = addrspacecast i8 addrspace(1)* %arrayidx to i8 addrspace(4)*
+  %5 = trunc i64 %call3 to i32
+  %6 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %2, i32 %5, i8 addrspace(4)* %4, i32 1, i32 1) #5
+  %7 = load %opencl.reserve_id_t*, %opencl.reserve_id_t* addrspace(3)* @test_pipe_workgroup_read_char.res_id, align 8, !tbaa !30
   ; CHECK-LLVM: call{{.*}}@__work_group_commit_read_pipe
   ; CHECK-SPIRV: GroupCommitReadPipe {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z27work_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %6, i32 1, i32 1) #2
+  tail call void @_Z27work_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %7, i32 1, i32 1) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -344,78 +348,77 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z28work_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare void @_Z27work_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z27work_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_subgroup_write_uint(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_subgroup_write_uint(i32 addrspace(1)* %src, %opencl.pipe_t addrspace(1)* %out_pipe) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !7 !kernel_arg_type_qual !8 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_subgroup_write_uint
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = tail call spir_func i32 @_Z18get_sub_group_sizev() #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %call1 = tail call spir_func i32 @_Z18get_sub_group_sizev() #6
   ; CHECK-LLVM: call{{.*}}@__sub_group_reserve_write_pipe
   ; CHECK-SPIRV: GroupReserveWritePipePackets {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %0 = tail call %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 %call1, i32 4, i32 4) #2
-  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #2
+  %0 = tail call %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %out_pipe, i32 %call1, i32 4, i32 4) #5
+  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #6
   br i1 %call2, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %call3 = tail call spir_func i32 @_Z22get_sub_group_local_idv() #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %call3 = tail call spir_func i32 @_Z22get_sub_group_local_idv() #6
+  %1 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %1, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %src, i64 %idxprom
-  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
-  %3 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 %call3, i8 addrspace(4)* %2, i32 4, i32 4) #2
+  %2 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %3 = addrspacecast i8 addrspace(1)* %2 to i8 addrspace(4)*
+  %4 = tail call i32 @_Z10write_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 %call3, i8 addrspace(4)* %3, i32 4, i32 4) #5
   ; CHECK-LLVM: call{{.*}}@__sub_group_commit_write_pipe
   ; CHECK-SPIRV: GroupCommitWritePipe {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z27sub_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #2
+  tail call void @_Z27sub_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %out_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
   ret void
-; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare spir_func i32 @_Z18get_sub_group_sizev() #1
+; Function Attrs: convergent
+declare spir_func i32 @_Z18get_sub_group_sizev() local_unnamed_addr #2
 
-declare %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z28sub_group_reserve_write_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare spir_func i32 @_Z22get_sub_group_local_idv() #1
+; Function Attrs: convergent
+declare spir_func i32 @_Z22get_sub_group_local_idv() local_unnamed_addr #2
 
-declare void @_Z27sub_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z27sub_group_commit_write_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
-
-
-; Function Attrs: nounwind
-define spir_kernel void @test_pipe_subgroup_read_uint(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) #0 {
+; Function Attrs: convergent nounwind
+define spir_kernel void @test_pipe_subgroup_read_uint(%opencl.pipe_t addrspace(1)* %in_pipe, i32 addrspace(1)* %dst) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !12 !kernel_arg_type !13 !kernel_arg_base_type !14 !kernel_arg_type_qual !15 !kernel_arg_host_accessible !9 !kernel_arg_pipe_depth !10 !kernel_arg_pipe_io !11 !kernel_arg_buffer_location !11 {
 ; CHECK-LLVM-LABEL: @test_pipe_subgroup_read_uint
 ; CHECK-SPIRV-LABEL: 5 Function
 ; CHECK-SPIRV-NEXT:  FunctionParameter {{[0-9]+}} [[PipeArgID:[0-9]+]]
 entry:
-  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #2
-  %call1 = tail call spir_func i32 @_Z18get_sub_group_sizev() #2
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #4
+  %call1 = tail call spir_func i32 @_Z18get_sub_group_sizev() #6
   ; CHECK-LLVM: call{{.*}}@__sub_group_reserve_read_pipe
   ; CHECK-SPIRV: GroupReserveReadPipePackets {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  %0 = tail call %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 %call1, i32 4, i32 4) #2
-  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #2
+  %0 = tail call %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)* %in_pipe, i32 %call1, i32 4, i32 4) #5
+  %call2 = tail call spir_func zeroext i1 @_Z19is_valid_reserve_id13ocl_reserveid(%opencl.reserve_id_t* %0) #6
   br i1 %call2, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %call3 = tail call spir_func i32 @_Z22get_sub_group_local_idv() #2
-  %sext = shl i64 %call, 32
-  %idxprom = ashr exact i64 %sext, 32
+  %call3 = tail call spir_func i32 @_Z22get_sub_group_local_idv() #6
+  %1 = shl i64 %call, 32
+  %idxprom = ashr exact i64 %1, 32
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %dst, i64 %idxprom
-  %1 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
-  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
-  %3 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 %call3, i8 addrspace(4)* %2, i32 4, i32 4) #2
+  %2 = bitcast i32 addrspace(1)* %arrayidx to i8 addrspace(1)*
+  %3 = addrspacecast i8 addrspace(1)* %2 to i8 addrspace(4)*
+  %4 = tail call i32 @_Z9read_pipePU3AS18ocl_pipe13ocl_reserveidjPU3AS4vjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 %call3, i8 addrspace(4)* %3, i32 4, i32 4) #5
   ; CHECK-LLVM: call{{.*}}@__sub_group_commit_read_pipe
   ; CHECK-SPIRV: GroupCommitReadPipe {{[0-9]+}} [[PipeArgID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-  tail call void @_Z26sub_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #2
+  tail call void @_Z26sub_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)* %in_pipe, %opencl.reserve_id_t* %0, i32 4, i32 4) #5
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -423,61 +426,67 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-SPIRV-LABEL: 1 FunctionEnd
 }
 
-declare %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32)
+declare %opencl.reserve_id_t* @_Z27sub_group_reserve_read_pipePU3AS18ocl_pipejjj(%opencl.pipe_t addrspace(1)*, i32, i32, i32) local_unnamed_addr
 
-declare void @_Z26sub_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32)
+declare void @_Z26sub_group_commit_read_pipePU3AS18ocl_pipe13ocl_reserveidjj(%opencl.pipe_t addrspace(1)*, %opencl.reserve_id_t*, i32, i32) local_unnamed_addr
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind }
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { convergent nounwind readnone }
+attributes #5 = { nounwind }
+attributes #6 = { convergent nounwind }
 
-!opencl.kernels = !{!0, !6, !11, !14, !20, !23, !26, !29, !30}
+!llvm.module.flags = !{!0}
 !opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!31}
-!opencl.ocl.version = !{!32}
-!opencl.used.extensions = !{!33}
-!opencl.used.optional.core.features = !{!33}
-!opencl.compiler.options = !{!33}
-!llvm.ident = !{!34}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+!llvm.ident = !{!3}
+!opencl.kernels = !{!33, !34, !35, !36, !37, !38, !39, !40, !41}
 
-!0 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_convenience_write_uint, !1, !2, !3, !4, !5}
-!1 = !{!"kernel_arg_addr_space", i32 1, i32 1}
-!2 = !{!"kernel_arg_access_qual", !"none", !"write_only"}
-!3 = !{!"kernel_arg_type", !"uint*", !"uint"}
-!4 = !{!"kernel_arg_base_type", !"uint*", !"uint"}
-!5 = !{!"kernel_arg_type_qual", !"", !"pipe"}
-!6 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_convenience_read_uint, !1, !7, !8, !9, !10}
-!7 = !{!"kernel_arg_access_qual", !"read_only", !"none"}
-!8 = !{!"kernel_arg_type", !"uint", !"uint*"}
-!9 = !{!"kernel_arg_base_type", !"uint", !"uint*"}
-!10 = !{!"kernel_arg_type_qual", !"pipe", !""}
-!11 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_write, !1, !2, !12, !13, !5}
-!12 = !{!"kernel_arg_type", !"int*", !"int"}
-!13 = !{!"kernel_arg_base_type", !"int*", !"int"}
-!14 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*, i32 addrspace(1)*)* @test_pipe_query_functions, !15, !16, !17, !18, !19}
-!15 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1}
-!16 = !{!"kernel_arg_access_qual", !"write_only", !"none", !"none"}
-!17 = !{!"kernel_arg_type", !"int", !"int*", !"int*"}
-!18 = !{!"kernel_arg_base_type", !"int", !"int*", !"int*"}
-!19 = !{!"kernel_arg_type_qual", !"pipe", !"", !""}
-!20 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_read, !1, !7, !21, !22, !10}
-!21 = !{!"kernel_arg_type", !"int", !"int*"}
-!22 = !{!"kernel_arg_base_type", !"int", !"int*"}
-!23 = !{void (i8 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_workgroup_write_char, !1, !2, !24, !25, !5}
-!24 = !{!"kernel_arg_type", !"char*", !"char"}
-!25 = !{!"kernel_arg_base_type", !"char*", !"char"}
-!26 = !{void (%opencl.pipe_t addrspace(1)*, i8 addrspace(1)*)* @test_pipe_workgroup_read_char, !1, !7, !27, !28, !10}
-!27 = !{!"kernel_arg_type", !"char", !"char*"}
-!28 = !{!"kernel_arg_base_type", !"char", !"char*"}
-!29 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_subgroup_write_uint, !1, !2, !3, !4, !5}
-!30 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_subgroup_read_uint, !1, !7, !8, !9, !10}
-!31 = !{i32 1, i32 2}
-!32 = !{i32 2, i32 0}
-!33 = !{}
-!34 = !{!"clang version 3.6.1"}
-!35 = !{!36, !36, i64 0}
-!36 = !{!"int", !37, i64 0}
-!37 = !{!"omnipotent char", !38, i64 0}
-!38 = !{!"Simple C/C++ TBAA"}
-!39 = !{!40, !40, i64 0}
-!40 = !{!"reserve_id_t", !37, i64 0}
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{}
+!3 = !{!"clang version 6.0.0"}
+!4 = !{i32 1, i32 1}
+!5 = !{!"none", !"write_only"}
+!6 = !{!"uint*", !"unsigned int"}
+!7 = !{!"uint*", !"uint"}
+!8 = !{!"", !"pipe"}
+!9 = !{i1 false, i1 false}
+!10 = !{i32 0, i32 0}
+!11 = !{!"", !""}
+!12 = !{!"read_only", !"none"}
+!13 = !{!"unsigned int", !"uint*"}
+!14 = !{!"uint", !"uint*"}
+!15 = !{!"pipe", !""}
+!16 = !{!"int*", !"int"}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{!"write_only", !"none", !"none"}
+!19 = !{!"int", !"int*", !"int*"}
+!20 = !{!"pipe", !"", !""}
+!21 = !{i1 false, i1 false, i1 false}
+!22 = !{i32 0, i32 0, i32 0}
+!23 = !{!"", !"", !""}
+!24 = !{!25, !25, i64 0}
+!25 = !{!"int", !26, i64 0}
+!26 = !{!"omnipotent char", !27, i64 0}
+!27 = !{!"Simple C/C++ TBAA"}
+!28 = !{!"int", !"int*"}
+!29 = !{!"char*", !"char"}
+!30 = !{!31, !31, i64 0}
+!31 = !{!"reserve_id_t", !26, i64 0}
+!32 = !{!"char", !"char*"}
+!33 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_convenience_write_uint}
+!34 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_convenience_read_uint}
+!35 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_write}
+!36 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*, i32 addrspace(1)*)* @test_pipe_query_functions}
+!37 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_read}
+!38 = !{void (i8 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_workgroup_write_char}
+!39 = !{void (%opencl.pipe_t addrspace(1)*, i8 addrspace(1)*)* @test_pipe_workgroup_read_char}
+!40 = !{void (i32 addrspace(1)*, %opencl.pipe_t addrspace(1)*)* @test_pipe_subgroup_write_uint}
+!41 = !{void (%opencl.pipe_t addrspace(1)*, i32 addrspace(1)*)* @test_pipe_subgroup_read_uint}

--- a/test/transcoding/spirv-types.ll
+++ b/test/transcoding/spirv-types.ll
@@ -179,6 +179,6 @@ attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-point
 !5 = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
 !6 = !{i32 1, i32 2}
 !7 = !{i32 2, i32 0}
-!8 = !{}
+!8 = !{!"cl_khr_fp16"}
 !9 = !{!"cl_images"}
 !10 = !{!"clang version 3.6.1 "}

--- a/test/vec_type_hint.ll
+++ b/test/vec_type_hint.ll
@@ -37,66 +37,57 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: define spir_kernel void @test_float()
 ; CHECK-LLVM-SAME: !vec_type_hint [[VFLOAT:![0-9]+]]
-; Function Attrs: nounwind
-define spir_kernel void @test_float() #0 {
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @test_float() local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 !vec_type_hint !4 {
 entry:
   ret void
 }
 
 ; CHECK-LLVM: define spir_kernel void @test_double()
 ; CHECK-LLVM-SAME: !vec_type_hint [[VDOUBLE:![0-9]+]]
-; Function Attrs: nounwind
-define spir_kernel void @test_double() #0 {
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @test_double() local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 !vec_type_hint !5 {
 entry:
   ret void
 }
 
 ; CHECK-LLVM: define spir_kernel void @test_uint()
 ; CHECK-LLVM-SAME: !vec_type_hint [[VUINT:![0-9]+]]
-; Function Attrs: nounwind
-define spir_kernel void @test_uint() #0 {
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @test_uint() local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 !vec_type_hint !6 {
 entry:
   ret void
 }
 
 ; CHECK-LLVM: define spir_kernel void @test_int()
 ; CHECK-LLVM-SAME: !vec_type_hint [[VINT:![0-9]+]]
-; Function Attrs: nounwind
-define spir_kernel void @test_int() #0 {
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @test_int() local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 !vec_type_hint !7 {
 entry:
   ret void
 }
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { norecurse nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 
-!opencl.kernels = !{!0, !7, !9, !11}
+!llvm.module.flags = !{!0}
 !opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!13}
-!opencl.ocl.version = !{!14}
-!opencl.used.extensions = !{!15}
-!opencl.used.optional.core.features = !{!15}
-!opencl.compiler.options = !{!15}
-!llvm.ident = !{!16}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+!llvm.ident = !{!3}
 
 ; CHECK-LLVM: [[VFLOAT]] = !{<4 x float> undef, i32 1}
 ; CHECK-LLVM: [[VDOUBLE]] = !{double undef, i32 1}
 ; CHECK-LLVM: [[VUINT]] = !{<4 x i32> undef, i32 1}
 ; CHECK-LLVM: [[VINT]] = !{<8 x i32> undef, i32 1}
 
-!0 = !{void ()* @test_float, !1, !2, !3, !4, !5, !6}
-!1 = !{!"kernel_arg_addr_space"}
-!2 = !{!"kernel_arg_access_qual"}
-!3 = !{!"kernel_arg_type"}
-!4 = !{!"kernel_arg_base_type"}
-!5 = !{!"kernel_arg_type_qual"}
-!6 = !{!"vec_type_hint", <4 x float> undef, i32 1}
-!7 = !{void ()* @test_double, !1, !2, !3, !4, !5, !8}
-!8 = !{!"vec_type_hint", double undef, i32 1}
-!9 = !{void ()* @test_uint, !1, !2, !3, !4, !5, !10}
-!10 = !{!"vec_type_hint", <4 x i32> undef, i32 0}
-!11 = !{void ()* @test_int, !1, !2, !3, !4, !5, !12}
-!12 = !{!"vec_type_hint", <8 x i32> undef, i32 1}
-!13 = !{i32 1, i32 2}
-!14 = !{i32 2, i32 0}
-!15 = !{}
-!16 = !{!"clang version 3.6.1"}
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{}
+!3 = !{!"clang version 6.0.0 (cfe/trunk)"}
+!4 = !{<4 x float> undef, i32 0}
+!5 = !{double undef, i32 0}
+!6 = !{<4 x i32> undef, i32 0}
+!7 = !{<8 x i32> undef, i32 1}


### PR DESCRIPTION
Clang 4.0 and higher produces kernel argument metadata attached to a
kernel:
'define spir_kernel void @foo(..)  #0 !kernel_arg_addr_space !1 ... {}'
'!1 = !{i32 1, i32 1}'

The patch updates SPIRVWriter to use metadata in this format.

'Old' format:
'!0 = !{void (float addrspace(1)*, ...)* @foo, !1, ...}'
'!1 = !{!"kernel_arg_addr_space", i32 1, ...}'
is no longer supported.

Also changing translation of !opencl.used.extension metadata to
OpSourceExtension instead of translation to OpExtension