### PR TITLE
Fix lit after changes in llvm reviewed in D51357

### DIFF
--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -27,7 +27,8 @@ except KeyError:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
-@LIT_SITE_CFG_IN_FOOTER@
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@LLVM_SPIRV_TEST_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
https://reviews.llvm.org/D51357
Remove LIT_SITE_CFG_IN_FOOTER.
Summary:
It's always replaced with the same (short) static string, so just put that there directly.
No intended behavior change.